### PR TITLE
Datamodules/mnist all to training

### DIFF
--- a/configs/datamodule/mnist_all_to_training.yaml
+++ b/configs/datamodule/mnist_all_to_training.yaml
@@ -1,0 +1,5 @@
+_target_: src.datamodules.mnist_all_to_training.MNISTAllToTraining
+data_dir: ${paths.data_dir}
+batch_size: 2048
+num_workers: 0
+pin_memory: False

--- a/src/datamodules/mnist_all_to_training.py
+++ b/src/datamodules/mnist_all_to_training.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+from pytorch_lightning import LightningDataModule
+from torch.utils.data import ConcatDataset, DataLoader, Dataset
+from torchvision.datasets import MNIST
+from torchvision.transforms import transforms
+
+
+class MNISTAllToTraining(LightningDataModule):
+    """This Data Module loads all MNIST dataset for training."""
+
+    def __init__(
+        self,
+        data_dir: str = "data/",
+        batch_size: int = 64,
+        num_workers: int = 0,
+        pin_memory: bool = False,
+    ) -> None:
+        super().__init__()
+        self.save_hyperparameters(logger=False)
+
+        self.transforms = transforms.Compose([transforms.ToTensor()])
+
+        self.data_train: Optional[Dataset] = None
+
+    def prepare_data(self) -> None:
+        """Download training data if needed."""
+        MNIST(self.hparams.data_dir, train=True, download=True)
+        MNIST(self.hparams.data_dir, train=False, download=True)
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        """Load data."""
+
+        if self.data_train is None:
+            trainset = MNIST(self.hparams.data_dir, train=True, transform=self.transforms)
+            testset = MNIST(self.hparams.data_dir, train=False, transform=self.transforms)
+            dataset = ConcatDataset(datasets=[trainset, testset])
+
+            self.data_train = dataset
+
+    def train_dataloader(self):
+        return DataLoader(
+            dataset=self.data_train,
+            batch_size=self.hparams.batch_size,
+            num_workers=self.hparams.num_workers,
+            pin_memory=self.hparams.pin_memory,
+            shuffle=True,
+        )
+
+    def teardown(self, stage: Optional[str] = None) -> None:
+        pass
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    import hydra
+    import omegaconf
+    import pyrootutils
+
+    root = pyrootutils.setup_root(__file__, pythonpath=True)
+    cfg = omegaconf.OmegaConf.load(root / "configs" / "datamodule" / "mnist_all_to_training.yaml")
+    cfg.data_dir = str(root / "data")
+    _ = hydra.utils.instantiate(cfg)

--- a/tests/datamodules/test_mnist_all_to_training.py
+++ b/tests/datamodules/test_mnist_all_to_training.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from src.datamodules.mnist_all_to_training import MNISTAllToTraining
+
+
+@pytest.mark.parametrize("batch_size", [32, 128])
+def test_mnist_all_to_training(batch_size: int):
+    data_dir = "data/"
+
+    dm = MNISTAllToTraining(data_dir=data_dir, batch_size=batch_size)
+    dm.prepare_data()
+
+    assert dm.data_train is None
+    assert Path(data_dir, "MNIST").exists()
+    assert Path(data_dir, "MNIST", "raw").exists()
+
+    dm.setup()
+    assert isinstance(dm.data_train, Dataset)
+    assert isinstance(dm.train_dataloader(), DataLoader)
+
+    assert len(dm.data_train) == 70_000
+
+    batch = next(iter(dm.train_dataloader()))
+    x, y = batch
+    assert len(x) == batch_size
+    assert len(y) == batch_size
+    assert x.dtype == torch.float32
+    assert y.dtype == torch.int64


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->
MNISTデータセット全てをTraining処理に流すためのデータモジュールを作成しました。
`val_dataloader`, `test_dataloader`は未定義であり、何も返しません。
また、MNISTデータセットのtrainとtestを結合し、合計70000のデータセットにしています。

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
