### PR TITLE
Utils/make grid of irrq prob figures

### DIFF
--- a/src/utils/figure_tools.py
+++ b/src/utils/figure_tools.py
@@ -72,3 +72,66 @@ def create_irrq_prob_figure(
     pax.set_xlabel("vector index", fontdict=label_fontdict)
 
     return figure
+
+
+def make_grid_of_irrq_prob_figures(
+    row: int,
+    col: int,
+    input_images: np.ndarray,
+    reconstruction_images: np.ndarray,
+    reconstructed_quantizing_images: np.ndarray,
+    probability_distributioins: np.ndarray,
+    base_fig_size: tuple[int, int] = (6.4, 4.8),
+    label_fontdict: Optional[dict] = None,
+    imshow_settings: Optional[dict] = None,
+) -> figure.Figure:
+    """Make grid of figures for logging output of softvq vae. If the number of images is smaller
+    than `row x col`, empty subfigures are shown in tail of the figure.
+
+    Arg:
+        row (int): Row size of grid.
+        col (int): Column size of grid.
+        input_images (np.ndarray): Input of vae.
+        reconstruction_images (np.ndarray): Output of vae.
+        quantized_reconstruction_images (np.ndarray): Reconstructed quantized image.
+        probability_distributions (np.ndarray): output `q_dist` of softvq.
+        base_fig_size (tuple[int, int]): Base size of figure. Expanded by `row` and `col`.
+        fontdict (Optional[dict]): See `create_irrq_prob_figure` docs.
+        imshow_settings (Optional[dict]): See `create_irrq_prob_figure` docs.
+
+    Shape:
+        input_images: (num, width, height, channels)
+        reconstruction_images: (num, width, height, channels)
+        quantized_reconstruction_image: (num, width, height, channels)
+        probability_distribution: (num, num_quantizing)
+
+    Returns:
+        output_figure (figure.Figure)
+    """
+
+    figsize = (base_fig_size[0] * col, base_fig_size[1] * row)
+    num_images = len(input_images)
+
+    root_fig = plt.figure(figsize=figsize)
+
+    subfigs = root_fig.subfigures(row, col, False)
+    index = 0
+    for r in range(row):
+        for c in range(col):
+            if index < num_images:
+                fig: figure.SubFigure = subfigs[r][c]
+
+                in_img = input_images[index]
+                rec_img = reconstruction_images[index]
+                rec_q_img = reconstructed_quantizing_images[index]
+                prob = probability_distributioins[index]
+                fig = create_irrq_prob_figure(in_img, rec_img, rec_q_img, prob, fig, label_fontdict, imshow_settings)
+            else:
+                break
+
+            index += 1
+
+        if not (index < num_images):
+            break
+
+    return root_fig

--- a/tests/utils/test_figure_tools.py
+++ b/tests/utils/test_figure_tools.py
@@ -3,6 +3,7 @@ import os
 import matplotlib.figure as figure
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 from src.utils import figure_tools as mod
 
@@ -33,4 +34,25 @@ def test_create_irrq_prob_figure():
 
     fig.savefig(os.path.join(result_dir, f"{__name__}.test_create_irrq_prob_figure.png"))
 
+    plt.close()
+
+
+@pytest.mark.parametrize("image_num", [6, 4])
+def test_make_grid_of_irrq_prob_figures(image_num: int):
+    f = mod.make_grid_of_irrq_prob_figures
+
+    row, col = 2, 3
+    in_imgs = np.random.rand(image_num, width, height, c)
+    rec_imgs = np.random.rand(image_num, width, height, c)
+    rq_imgs = np.random.rand(image_num, width, height, c)
+    probs = np.random.rand(image_num, num_quantizing)
+    base_fig_size = (6.4, 4.8)
+    fontdict = {"fontsize": 10}
+    imshow_settings = {"vmin": 0.0, "vmax": 1.0}
+
+    fig = f(row, col, in_imgs, rec_imgs, rq_imgs, probs, base_fig_size, fontdict, imshow_settings)
+
+    assert isinstance(fig, figure.Figure)
+
+    fig.savefig(os.path.join(result_dir, f"{__name__}.test_make_grid_of_irrq_prob_figures.{image_num}.png"))
     plt.close()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

`make_grid_of_irrq_prob_figures`を作成しました。
`create_irrq_prob_figure`で作成されるfigureをrow x colのように 並べたfigureを作成する関数です。
![tests utils test_figure_tools test_make_grid_of_irrq_prob_figures 6](https://user-images.githubusercontent.com/59220704/198828094-2e0d8776-12fa-4d1e-be16-0a8cab0025c8.png)
## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
