### PR TITLE
Components/straight softvq vae

### DIFF
--- a/src/models/components/straight_softvq_vae.py
+++ b/src/models/components/straight_softvq_vae.py
@@ -1,0 +1,55 @@
+from typing import Tuple
+
+import torch.nn as nn
+from torch import Tensor
+
+from .dense_image_vae import sample
+
+
+class StraightSoftVQVAE(nn.Module):
+    """Straight SoftVQ VAE class.
+    This model data flow is,
+
+        X - [Encoder] -> mean, logvar - [sample] -> z
+            - [SoftVQ] -> quantized - [Decoder] -> X_hat
+
+    So, don't need to compute quantizing loss.
+    """
+
+    def __init__(self, encoder: nn.Module, decoder: nn.Module, softvq: nn.Module) -> None:
+        super().__init__()
+        """Constructor.
+        Args:
+            encoder (nn.Module): This forward pass must return `mean` and `logvar`.
+            decoder (nn.Module): decoder of vae.
+            softvq (nn.Module): The args of this forward pass must have `detach_distribution_grad` option.
+        """
+
+        self.encoder = encoder
+        self.decoder = decoder
+        self.softvq = softvq
+
+    def forward(self, x: Tensor) -> Tuple[Tensor, ...]:
+        """Forward pass of Straight SoftVQ VAE
+        Args:
+            x (Tensor): Input data of vae.
+
+        Returns:
+            x_hat (Tensor): Reconstructed input data/
+            mean (Tensor): Mean tensor of encoder output of vae
+            logvar (Tensor): log variant of encoder output of vae
+            q_dist (Tensor): Quantizing distribution (Attention map).
+
+        Shape:
+            x: (batch, *)
+            x_hat: same shape of x
+            mean: (*, latent_size)
+            logvar: sames shape of mean.
+            q_dist: (*, num_quantizing)
+        """
+
+        mean, logvar = self.encoder(x)
+        z = sample(mean, logvar)
+        quantized, q_dist = self.softvq(z, detach_distribution_grad=False)
+        x_hat = self.decoder(quantized).view(x.shape)
+        return x_hat, mean, logvar, quantized, q_dist

--- a/tests/models/components/test_straight_softvq_vae.py
+++ b/tests/models/components/test_straight_softvq_vae.py
@@ -1,0 +1,52 @@
+import torch
+
+from src.models.components.straight_softvq_vae import StraightSoftVQVAE
+from src.models.components.dense_image_vae import Encoder, Decoder
+from src.models.components.softvq import SoftVectorQuantizing
+
+batch_size = 16
+input_size = 784
+lin1sz = 256
+lin2sz = 64
+latent_size = 16
+num_quantizing = 10
+
+
+def test__init__():
+    cls = StraightSoftVQVAE
+
+    encoder = Encoder(input_size, lin1sz, lin2sz, latent_size)
+    decoder = Decoder(latent_size, lin2sz, lin1sz, input_size)
+    softvq = SoftVectorQuantizing(num_quantizing, latent_size)
+
+    ssvqvae = cls(encoder, decoder, softvq)
+
+    assert ssvqvae.encoder is encoder
+    assert ssvqvae.decoder is decoder
+    assert ssvqvae.softvq is softvq
+
+
+def test_forward():
+    cls = StraightSoftVQVAE
+
+    encoder = Encoder(input_size, lin1sz, lin2sz, latent_size)
+    decoder = Decoder(latent_size, lin2sz, lin1sz, input_size)
+    softvq = SoftVectorQuantizing(num_quantizing, latent_size)
+
+    ssvqvae = cls(encoder, decoder, softvq)
+    dummy = torch.randn(batch_size, input_size)
+
+    outputs = ssvqvae.forward(dummy)
+
+    assert len(outputs) == 5
+    x_hat, mean, logvar, quantized, q_dist = outputs
+    assert isinstance(x_hat, torch.Tensor)
+    assert isinstance(mean, torch.Tensor)
+    assert isinstance(logvar, torch.Tensor)
+    assert isinstance(quantized, torch.Tensor)
+    assert isinstance(q_dist, torch.Tensor)
+    assert x_hat.shape == (batch_size, input_size)
+    assert mean.shape == (batch_size, latent_size)
+    assert logvar.shape == (batch_size, latent_size)
+    assert quantized.shape == (batch_size, latent_size)
+    assert q_dist.shape == (batch_size, num_quantizing)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Straight SoftVQ VAEクラスを作成しました。純粋なSoftVQVAEとは異なり、Quantizing distributionが単なるAttention Mapとなるだけなので、量子化誤差を計算しません。
モデルのデータフローは次のようになっています。

X - [Encoder] -> (mean, logvar) - [sample] -> z  - [SoftVQ] -> quantized - [Decoder] -> X_hat

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
